### PR TITLE
feat: add optional Atlas Cloud provider to manga drama

### DIFF
--- a/skills/canghe-manga-drama/SKILL.md
+++ b/skills/canghe-manga-drama/SKILL.md
@@ -17,7 +17,12 @@ description: 漫剧生成器 - 基于 Seedance 的漫画风格短剧生成工具
 
 ## 前置要求
 
-需要设置 `ARK_API_KEY` 环境变量。
+选择一个视频生成 provider 并设置对应环境变量：
+
+| Provider | 环境变量 | 默认模型 |
+|----------|----------|----------|
+| `volcengine`（默认） | `ARK_API_KEY` | `doubao-seedance-1-5-pro-251215` |
+| `atlas` | `ATLASCLOUD_API_KEY` | `bytedance/seedance-2.5/image-to-video` |
 
 ### 配置方式（推荐）
 
@@ -35,6 +40,12 @@ ARK_API_KEY=your-actual-api-key-here
 
 ```bash
 export ARK_API_KEY="your-api-key"
+```
+
+使用 Atlas Cloud 时：
+
+```bash
+export ATLASCLOUD_API_KEY="your-api-key"
 ```
 
 ### 加载优先级
@@ -60,6 +71,16 @@ python3 scripts/manga_drama.py generate \
   --theme "校园日常" \
   --scenes 3 \
   --send-feishu
+```
+
+Atlas Cloud 是可选 provider，不改变默认的火山方舟流程：
+
+```bash
+python3 scripts/manga_drama.py generate \
+  --image /path/to/character.png \
+  --theme "校园日常" \
+  --scenes 3 \
+  --provider atlas
 ```
 
 ### 2. 根据脚本生成漫剧
@@ -126,6 +147,8 @@ python3 scripts/manga_drama.py from-script \
 | `--scenes` | ❌ | 分镜数量（默认3） |
 | `--output` | ❌ | 输出目录（默认~/Desktop） |
 | `--send-feishu` | ❌ | 发送到飞书 |
+| `--provider` | ❌ | `volcengine`（默认）或 `atlas` |
+| `--model` | ❌ | 覆盖所选 provider 的默认模型 ID |
 
 ### from-script 命令
 
@@ -134,6 +157,8 @@ python3 scripts/manga_drama.py from-script \
 | `--script` | ✅ | 脚本文件路径 |
 | `--image` | ✅ | 主角图片路径 |
 | `--send-feishu` | ❌ | 发送到飞书 |
+| `--provider` | ❌ | `volcengine`（默认）或 `atlas` |
+| `--model` | ❌ | 覆盖所选 provider 的默认模型 ID |
 
 ### create-script 命令
 
@@ -196,6 +221,8 @@ python3 scripts/manga_drama.py from-script \
 3. 每个分镜 → 调用 Seedance 图生视频
 4. 可选 → 发送到飞书
 ```
+
+Atlas Cloud provider 会将本地主角图片作为首帧传入，并使用图片本身的宽高比。任务提交只执行一次，状态查询采用有界退避，最长等待 10 分钟。
 
 ### 视频规格
 

--- a/skills/canghe-manga-drama/scripts/manga_drama.py
+++ b/skills/canghe-manga-drama/scripts/manga_drama.py
@@ -27,7 +27,6 @@ except ImportError:
 load_env()
 
 # 默认配置
-DEFAULT_MODEL = "doubao-seedance-1-5-pro-251215"
 DEFAULT_RATIO = "9:16"  # 漫剧常用竖屏
 DEFAULT_RESOLUTION = "1080p"
 DEFAULT_DURATION = 5  # 每个分镜5秒
@@ -132,9 +131,10 @@ def create_drama_script(
 def generate_scene_video(
     scene: Dict,
     character_image: str,
-    model: str = DEFAULT_MODEL,
+    model: Optional[str] = None,
     output_dir: str = "~/Desktop",
-    send_feishu: bool = False
+    send_feishu: bool = False,
+    provider: str = "volcengine"
 ) -> str:
     """
     生成分镜视频
@@ -166,7 +166,8 @@ def generate_scene_video(
         ratio=scene['ratio'],
         resolution=scene['resolution'],
         output_dir=output_dir,
-        send_feishu=send_feishu
+        send_feishu=send_feishu,
+        provider=provider
     )
     
     return video_path
@@ -176,7 +177,9 @@ def generate_drama(
     script_file: str,
     character_image: str,
     output_dir: str = "~/Desktop",
-    send_feishu: bool = False
+    send_feishu: bool = False,
+    provider: str = "volcengine",
+    model: Optional[str] = None
 ) -> List[str]:
     """
     根据脚本生成完整漫剧
@@ -214,8 +217,10 @@ def generate_drama(
             video_path = generate_scene_video(
                 scene=scene,
                 character_image=character_image,
+                model=model,
                 output_dir=str(drama_dir),
-                send_feishu=send_feishu
+                send_feishu=send_feishu,
+                provider=provider
             )
             video_files.append(video_path)
         except Exception as e:
@@ -235,7 +240,9 @@ def quick_generate(
     theme: str,
     num_scenes: int = 3,
     output_dir: str = "~/Desktop",
-    send_feishu: bool = False
+    send_feishu: bool = False,
+    provider: str = "volcengine",
+    model: Optional[str] = None
 ) -> List[str]:
     """
     快速生成漫剧 - 自动创建脚本并生成
@@ -320,7 +327,9 @@ def quick_generate(
         script_file=str(script_file),
         character_image=character_image,
         output_dir=output_dir,
-        send_feishu=send_feishu
+        send_feishu=send_feishu,
+        provider=provider,
+        model=model
     )
 
 
@@ -350,6 +359,9 @@ def main():
     p_generate.add_argument("--scenes", "-n", type=int, default=3, help="分镜数量（默认3）")
     p_generate.add_argument("--output", "-o", default="~/Desktop", help="输出目录")
     p_generate.add_argument("--send-feishu", action="store_true", help="发送到飞书")
+    p_generate.add_argument("--provider", choices=["volcengine", "atlas"], default="volcengine",
+                            help="视频生成 provider（默认: volcengine）")
+    p_generate.add_argument("--model", help="覆盖 provider 的默认模型 ID")
     
     # from-script - 根据脚本生成
     p_from_script = subparsers.add_parser("from-script", help="根据脚本生成漫剧")
@@ -357,6 +369,9 @@ def main():
     p_from_script.add_argument("--image", "-i", required=True, help="主角图片路径")
     p_from_script.add_argument("--output", "-o", default="~/Desktop", help="输出目录")
     p_from_script.add_argument("--send-feishu", action="store_true", help="发送到飞书")
+    p_from_script.add_argument("--provider", choices=["volcengine", "atlas"], default="volcengine",
+                               help="视频生成 provider（默认: volcengine）")
+    p_from_script.add_argument("--model", help="覆盖 provider 的默认模型 ID")
     
     # create-script - 创建脚本模板
     p_create = subparsers.add_parser("create-script", help="创建脚本模板")
@@ -371,8 +386,9 @@ def main():
         parser.print_help()
         sys.exit(1)
     
-    # 设置 API Key
-    require_env_key("ARK_API_KEY")
+    if args.command != "create-script":
+        key_name = "ATLASCLOUD_API_KEY" if args.provider == "atlas" else "ARK_API_KEY"
+        require_env_key(key_name)
     
     try:
         if args.command == "generate":
@@ -382,7 +398,9 @@ def main():
                 theme=args.theme,
                 num_scenes=args.scenes,
                 output_dir=args.output,
-                send_feishu=args.send_feishu
+                send_feishu=args.send_feishu,
+                provider=args.provider,
+                model=args.model
             )
             print(f"\n🎉 漫剧生成完成! 共 {len(video_files)} 个视频")
             for i, vf in enumerate(video_files, 1):
@@ -394,7 +412,9 @@ def main():
                 script_file=args.script,
                 character_image=args.image,
                 output_dir=args.output,
-                send_feishu=args.send_feishu
+                send_feishu=args.send_feishu,
+                provider=args.provider,
+                model=args.model
             )
             print(f"\n🎉 漫剧生成完成! 共 {len(video_files)} 个视频")
         

--- a/skills/canghe-manga-drama/scripts/seedance_video.py
+++ b/skills/canghe-manga-drama/scripts/seedance_video.py
@@ -8,10 +8,12 @@ import os
 import sys
 import json
 import base64
+import urllib.error
 import urllib.request
 import ssl
 import time
 from pathlib import Path
+from typing import Optional
 
 # 添加 common 模块到路径
 COMMON_DIR = Path(__file__).parent.parent.parent / "common"
@@ -32,12 +34,103 @@ ssl_context.verify_mode = ssl.CERT_NONE
 # API配置
 BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
 DEFAULT_MODEL = "doubao-seedance-1-5-pro-251215"
+ATLAS_BASE_URL = "https://api.atlascloud.ai/api/v1"
+ATLAS_DEFAULT_MODEL = "bytedance/seedance-2.5/image-to-video"
 
 
 def image_to_base64(image_path: str) -> str:
     """将图片转为base64"""
     with open(image_path, "rb") as f:
         return base64.b64encode(f.read()).decode("utf-8")
+
+
+def image_to_data_url(image_path: str) -> str:
+    ext = Path(image_path).suffix.lower().lstrip(".")
+    mime_type = "png" if ext == "png" else "jpeg"
+    return f"data:image/{mime_type};base64,{image_to_base64(image_path)}"
+
+
+def request_json(
+    url: str,
+    headers: dict,
+    method: str = "GET",
+    body: Optional[dict] = None,
+    context: Optional[ssl.SSLContext] = None
+) -> dict:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, context=context, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"API 请求失败 ({exc.code}): {detail}") from exc
+
+
+def generate_atlas_video(
+    prompt: str,
+    image_path: str,
+    model: str,
+    duration: int,
+    resolution: str,
+    timeout: int = 600
+) -> str:
+    api_key = require_env_key("ATLASCLOUD_API_KEY")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json"
+    }
+    body = {
+        "model": model,
+        "prompt": prompt,
+        "image": image_to_data_url(image_path),
+        "duration": duration,
+        "resolution": resolution,
+        "ratio": "adaptive",
+        "generate_audio": True
+    }
+
+    print("🎬 创建 Atlas Cloud 视频生成任务...")
+    result = request_json(
+        f"{ATLAS_BASE_URL}/model/generateVideo",
+        headers,
+        method="POST",
+        body=body
+    )
+    if result.get("code") not in {None, 200}:
+        raise RuntimeError(f"Atlas Cloud 创建任务失败: {result}")
+    task_id = result.get("data", {}).get("id")
+    if not task_id:
+        raise RuntimeError(f"Atlas Cloud 未返回任务 ID: {result}")
+
+    print(f"✅ 任务创建: {task_id}")
+    print("⏳ 等待视频生成...")
+    deadline = time.monotonic() + timeout
+    delay = 10
+
+    while time.monotonic() < deadline:
+        time.sleep(delay)
+        result = request_json(
+            f"{ATLAS_BASE_URL}/model/prediction/{task_id}",
+            headers
+        )
+        if result.get("code") not in {None, 200}:
+            raise RuntimeError(f"Atlas Cloud 查询任务失败: {result}")
+        data = result.get("data", {})
+        status = data.get("status")
+
+        if status in {"completed", "succeeded"}:
+            outputs = data.get("outputs") or []
+            if not outputs:
+                raise RuntimeError(f"Atlas Cloud 任务完成但没有视频输出: {result}")
+            return outputs[0]
+        if status in {"failed", "timeout"}:
+            raise RuntimeError(f"Atlas Cloud 视频生成失败: {result}")
+
+        print(f"   状态: {status}...", end="\r", flush=True)
+        delay = min(int(delay * 1.5), 30)
+
+    raise TimeoutError(f"Atlas Cloud 视频生成等待超时 ({timeout} 秒): {task_id}")
 
 
 def analyze_image(image_path: str) -> str:
@@ -71,12 +164,13 @@ def download_video(video_url: str, output_path: str):
 def generate_video_task(
     prompt: str,
     image_path: str = None,
-    model: str = DEFAULT_MODEL,
+    model: Optional[str] = None,
     duration: int = 5,
     ratio: str = "9:16",
     resolution: str = "1080p",
     output_dir: str = "~/Desktop",
-    send_feishu: bool = False
+    send_feishu: bool = False,
+    provider: str = "volcengine"
 ) -> str:
     """
     直接调用 Seedance API 生成视频（无需 SDK）
@@ -84,13 +178,33 @@ def generate_video_task(
     Returns:
         生成的视频路径
     """
-    # 加载环境变量获取 API Key
-    load_env()
-    api_key = require_env_key("ARK_API_KEY")
-
     # 生成输出文件名
     timestamp = int(time.time())
     output_file = Path(output_dir).expanduser() / f"scene_{timestamp}.mp4"
+
+    if provider == "atlas":
+        if not image_path or not os.path.exists(image_path):
+            raise ValueError("Atlas Cloud 图生视频需要有效的本地主角图片")
+        selected_model = model or ATLAS_DEFAULT_MODEL
+        print("ℹ️  Atlas Cloud 会保留参考图片比例，忽略分镜 ratio 参数")
+        video_url = generate_atlas_video(
+            prompt=prompt,
+            image_path=image_path,
+            model=selected_model,
+            duration=duration,
+            resolution=resolution
+        )
+        print("🎉 视频生成成功!")
+        print(f"   URL: {video_url}")
+        download_video(video_url, str(output_file))
+        return str(output_file)
+
+    if provider != "volcengine":
+        raise ValueError(f"不支持的 provider: {provider}")
+
+    load_env()
+    api_key = require_env_key("ARK_API_KEY")
+    selected_model = model or DEFAULT_MODEL
 
     # 构建请求
     headers = {
@@ -112,7 +226,7 @@ def generate_video_task(
     content.append({"type": "text", "text": prompt})
 
     body = {
-        "model": model,
+        "model": selected_model,
         "content": content,
         "duration": duration,
         "ratio": ratio,

--- a/skills/canghe-manga-drama/tests/test_seedance_video.py
+++ b/skills/canghe-manga-drama/tests/test_seedance_video.py
@@ -1,0 +1,122 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import seedance_video
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class AtlasVideoTests(unittest.TestCase):
+    @patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=False)
+    @patch.object(seedance_video, "download_video")
+    @patch.object(seedance_video.time, "sleep", return_value=None)
+    @patch.object(seedance_video.urllib.request, "urlopen")
+    def test_atlas_submits_once_and_polls_prediction(
+        self,
+        urlopen,
+        _sleep,
+        download_video
+    ):
+        urlopen.side_effect = [
+            FakeResponse({"code": 200, "data": {"id": "prediction-1"}}),
+            FakeResponse({
+                "code": 200,
+                "data": {
+                    "status": "completed",
+                    "outputs": ["https://example.com/video.mp4"]
+                }
+            })
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            image_path = Path(temp_dir) / "character.png"
+            image_path.write_bytes(b"png-data")
+            result = seedance_video.generate_video_task(
+                prompt="漫画角色挥手",
+                image_path=str(image_path),
+                duration=5,
+                resolution="1080p",
+                output_dir=temp_dir,
+                provider="atlas"
+            )
+
+        self.assertEqual(urlopen.call_count, 2)
+        submit_request = urlopen.call_args_list[0].args[0]
+        prediction_request = urlopen.call_args_list[1].args[0]
+        submit_body = json.loads(submit_request.data.decode("utf-8"))
+        self.assertEqual(submit_request.method, "POST")
+        self.assertEqual(
+            submit_body["model"],
+            "bytedance/seedance-2.5/image-to-video"
+        )
+        self.assertEqual(submit_body["ratio"], "adaptive")
+        self.assertTrue(submit_body["image"].startswith("data:image/png;base64,"))
+        self.assertIn("/model/prediction/prediction-1", prediction_request.full_url)
+        download_video.assert_called_once_with(
+            "https://example.com/video.mp4",
+            result
+        )
+
+    @patch.dict(os.environ, {"ARK_API_KEY": "test-key"}, clear=False)
+    @patch.object(seedance_video, "download_video")
+    @patch.object(seedance_video.time, "sleep", return_value=None)
+    @patch.object(seedance_video.urllib.request, "urlopen")
+    def test_volcengine_remains_the_default_provider(
+        self,
+        urlopen,
+        _sleep,
+        download_video
+    ):
+        urlopen.side_effect = [
+            FakeResponse({"id": "task-1"}),
+            FakeResponse({
+                "status": "succeeded",
+                "content": {"video_url": "https://example.com/volc.mp4"}
+            })
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            image_path = Path(temp_dir) / "character.png"
+            image_path.write_bytes(b"png-data")
+            result = seedance_video.generate_video_task(
+                prompt="漫画角色挥手",
+                image_path=str(image_path),
+                output_dir=temp_dir
+            )
+
+        submit_request = urlopen.call_args_list[0].args[0]
+        submit_body = json.loads(submit_request.data.decode("utf-8"))
+        self.assertIn("ark.cn-beijing.volces.com", submit_request.full_url)
+        self.assertEqual(
+            submit_body["model"],
+            "doubao-seedance-1-5-pro-251215"
+        )
+        download_video.assert_called_once_with(
+            "https://example.com/volc.mp4",
+            result
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an explicit `--provider atlas` path for `canghe-manga-drama`
- use Seedance 2.5 image-to-video while preserving `volcengine` as the default
- submit generation once and poll prediction status with a bounded backoff
- document provider-specific keys and add mock coverage for both providers

## Testing

- `python3 -B -m unittest discover -s skills/canghe-manga-drama/tests -v`
- parsed the modified Python files with `ast.parse`
- verified `generate` and `from-script` CLI help

No live generation request was submitted during testing.